### PR TITLE
Refactor hunk header line in delta.rs

### DIFF
--- a/src/delta.rs
+++ b/src/delta.rs
@@ -375,21 +375,26 @@ fn handle_hunk_header_line(
     plus_file: &str,
     config: &Config,
 ) -> std::io::Result<()> {
+    let mut pad = false;
     let decoration_ansi_term_style;
     let draw_fn = match config.hunk_header_style.decoration_style {
         DecorationStyle::Box(style) => {
+            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed
         }
         DecorationStyle::BoxWithUnderline(style) => {
+            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed_with_underline
         }
         DecorationStyle::BoxWithOverline(style) => {
+            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed // TODO: not implemented
         }
         DecorationStyle::BoxWithUnderOverline(style) => {
+            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed // TODO: not implemented
         }
@@ -418,8 +423,8 @@ fn handle_hunk_header_line(
         }
         draw_fn(
             painter.writer,
-            &format!("{} ", line),
-            &format!("{} ", raw_line),
+            &format!("{}{}", line, if pad { " " } else { "" }),
+            &format!("{}{}", raw_line, if pad { " " } else { "" }),
             &config.decorations_width,
             config.hunk_header_style,
             decoration_ansi_term_style,

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -136,11 +136,9 @@ where
             painter.paint_buffered_minus_and_plus_lines();
             state = State::HunkHeader;
             painter.set_highlighter();
-            if should_handle(&state, config) {
-                painter.emit()?;
-                handle_hunk_header_line(&mut painter, &line, &raw_line, &plus_file, config)?;
-                continue;
-            }
+            painter.emit()?;
+            handle_hunk_header_line(&mut painter, &line, &raw_line, &plus_file, config)?;
+            continue;
         } else if source == Source::DiffUnified && line.starts_with("Only in ")
             || line.starts_with("Submodule ")
             || line.starts_with("Binary files ")
@@ -193,9 +191,6 @@ where
 
 /// Should a handle_* function be called on this element?
 fn should_handle(state: &State, config: &Config) -> bool {
-    if *state == State::HunkHeader && config.line_numbers {
-        return true;
-    }
     let style = config.get_style(state);
     !(style.is_raw && style.decoration_style == DecorationStyle::NoDecoration)
 }


### PR DESCRIPTION
## My purpose

9b58d5e will fail tests because hunk-header-line causes whitespaces, then assert_eq triggers.
<img width="1314" alt="ss" src="https://user-images.githubusercontent.com/41639488/94327384-9922a680-ffe5-11ea-93c9-7b46d4c5a635.png">

To avoid this, https://github.com/dandavison/delta/pull/333 is required.

The code will be clean because you don't need to use pad everytime, but as dandavison said it changes behavior.
https://github.com/dandavison/delta/pull/333#issuecomment-699079852

## Not changing behavior also simplify the `should_handle` process.

https://github.com/ryuta69/delta/pull/2/files

This never changes behavior, and simplify the code.
I think this is the ideal.